### PR TITLE
Await POST request before refreshing page

### DIFF
--- a/app/board.html
+++ b/app/board.html
@@ -66,8 +66,9 @@
         fetch('/apps/board', {
             method: 'POST',
             body: JSON.stringify({[tag]: data})
+        }).then(() => {
+          location.reload()
         })
-        location.reload()
     }
 
     function postFollow()


### PR DESCRIPTION
I am experiencing a bug where the "save changes" button doesn't save changes.

I believe it is because the JS `fetch` function is asynchronous and the refresh line gets hit before the async fetch goes through.